### PR TITLE
Make Boost::system an optional component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ find_package(pybind11 2.13 REQUIRED)
 
 if(NOT CUIKMOLMAKER_BUILD_AGAINST_PIP_RDKIT)
     # Find Boost package
-    find_package(Boost REQUIRED COMPONENTS system serialization iostreams)
+    find_package(Boost REQUIRED COMPONENTS serialization iostreams OPTIONAL_COMPONENTS system)
     message(STATUS "Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
     message(STATUS "Boost_LIBRARIES: ${Boost_LIBRARIES}")
     message(STATUS "Building against system RDKit from conda")


### PR DESCRIPTION
## Summary
- Changed `Boost::system` from a required component to an optional component in `find_package(Boost ...)` to avoid build failures on platforms where it is not available.

## Test plan
- [ ] Verify the build succeeds on Linux (conda-forge RDKit)
- [ ] Verify the build succeeds on Windows (conda-forge RDKit)
- [ ] Verify the build succeeds on macOS (conda-forge RDKit)

Made with [Cursor](https://cursor.com)